### PR TITLE
[DOI-1238] Improve assisted shopping endpoint performance

### DIFF
--- a/doppler-integrations-data/Helpers/NullTreatment.cs
+++ b/doppler-integrations-data/Helpers/NullTreatment.cs
@@ -12,7 +12,6 @@ namespace DopplerIntegrationsData.Helpers
         private const short DEFAULT_SHORT_VALUE = 0;
         private const long DEFAULT_LONG_VALUE = 0;
         private const double DEFAULT_DOUBLE_VALUE = 0;
-        private const bool DEFAULT_BOOLEAN_VALUE = false;
         private const byte DEFAULT_BYTE_VALUE = 0;
         private readonly char _dEFAULT_CHAR_VALUE = char.MinValue;
 
@@ -30,119 +29,63 @@ namespace DopplerIntegrationsData.Helpers
 
         public char GetChar(object possibleChar)
         {
-            try
-            {
-                var val = char.Parse(possibleChar.ToString());
-                return val;
-            }
-            catch
-            {
-                return _dEFAULT_CHAR_VALUE;
-            }
+            return char.TryParse(possibleChar.ToString(), out var val)
+                ? val
+                : _dEFAULT_CHAR_VALUE;
         }
 
         public static uint GetUInt(object possibleUInt)
         {
-            try
-            {
-                var val = uint.Parse(possibleUInt.ToString(), CultureInfo.InvariantCulture);
-                return val;
-            }
-            catch
-            {
-                return DEFAULT_UINT_VALUE;
-            }
+            return uint.TryParse(possibleUInt.ToString(), CultureInfo.InvariantCulture, out var val)
+                ? val
+                : DEFAULT_UINT_VALUE;
         }
 
         public static int GetInt(object possibleInt)
         {
-            try
-            {
-                var val = int.Parse(possibleInt.ToString(), CultureInfo.InvariantCulture);
-                return val;
-            }
-            catch
-            {
-                return DEFAULT_INT_VALUE;
-            }
+            return int.TryParse(possibleInt.ToString(), CultureInfo.InvariantCulture, out var val)
+                ? val
+                : DEFAULT_INT_VALUE;
         }
 
         public static long GetLong(object possibleLong)
         {
-            try
-            {
-                var val = long.Parse(possibleLong.ToString(), CultureInfo.InvariantCulture);
-                return val;
-            }
-            catch
-            {
-                return DEFAULT_LONG_VALUE;
-            }
+            return long.TryParse(possibleLong.ToString(), CultureInfo.InvariantCulture, out var val)
+                ? val
+                : DEFAULT_LONG_VALUE;
         }
 
         public static double GetDouble(object possibleDouble)
         {
-            try
-            {
-                var val = double.Parse(possibleDouble.ToString(), CultureInfo.InvariantCulture);
-                return val;
-            }
-            catch
-            {
-                return DEFAULT_DOUBLE_VALUE;
-            }
+            return double.TryParse(possibleDouble.ToString(), CultureInfo.InvariantCulture, out var val)
+                ? val
+                : DEFAULT_DOUBLE_VALUE;
         }
 
         public static bool GetBoolean(object possibleBoolean)
         {
-            try
-            {
-                var val = bool.Parse(possibleBoolean.ToString());
-                return val;
-            }
-            catch
-            {
-                return DEFAULT_BOOLEAN_VALUE;
-            }
+            return bool.TryParse(possibleBoolean.ToString(), out var val) && val;
         }
 
         public static DateTime GetDateTime(object possibleDateTime)
         {
-            try
-            {
-                var val = DateTime.Parse(possibleDateTime.ToString(), CultureInfo.InvariantCulture);
-                return val;
-            }
-            catch
-            {
-                return DateTime.MinValue;
-            }
+            return DateTime.TryParse(possibleDateTime.ToString(), CultureInfo.InvariantCulture, out var val)
+                ? val
+                : DateTime.MinValue;
         }
 
         public static byte GetByte(object possibleByte)
         {
-            try
-            {
-                var val = byte.Parse(possibleByte.ToString(), CultureInfo.InvariantCulture);
-                return val;
-            }
-            catch
-            {
-                return DEFAULT_BYTE_VALUE;
-            }
+            return byte.TryParse(possibleByte.ToString(), CultureInfo.InvariantCulture, out var val)
+                ? val
+                : DEFAULT_BYTE_VALUE;
         }
 
         public static short GetShort(object possibleShort)
         {
-            try
-            {
-                var val = short.Parse(possibleShort.ToString(), CultureInfo.InvariantCulture);
-                return val;
-            }
-            catch
-            {
-                return DEFAULT_SHORT_VALUE;
-            }
+            return short.TryParse(possibleShort.ToString(), CultureInfo.InvariantCulture, out var val)
+                ? val
+                : DEFAULT_SHORT_VALUE;
         }
 
         public static object GetObject(object possibleObject)


### PR DESCRIPTION
The issue was laying on the DateTime.Parse() in combination with the try/catch, because it seems some dates were not parsing correctly and catching the error was making the performance issues.
Either way, I just went and replaced every parse for TryParse instead and avoid the try/catch too.